### PR TITLE
Additional channel/chat lifecycle events

### DIFF
--- a/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/teams/TeamsActivityHandler.java
+++ b/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/teams/TeamsActivityHandler.java
@@ -416,8 +416,43 @@ public class TeamsActivityHandler extends ActivityHandler {
                             turnContext
                         );
 
+                    case "teamArchived":
+                        return onTeamsTeamArchived(
+                            channelData.value().getChannel(),
+                            channelData.value().getTeam(),
+                            turnContext
+                        );
+
+                    case "teamDeleted":
+                        return onTeamsTeamDeleted(
+                            channelData.value().getChannel(),
+                            channelData.value().getTeam(),
+                            turnContext
+                        );
+
+                    case "teamHardDeleted":
+                        return onTeamsTeamHardDeleted(
+                            channelData.value().getChannel(),
+                            channelData.value().getTeam(),
+                            turnContext
+                        );
+
                     case "teamRenamed":
                         return onTeamsTeamRenamed(
+                            channelData.value().getChannel(),
+                            channelData.value().getTeam(),
+                            turnContext
+                        );
+
+                    case "teamRestored":
+                        return onTeamsTeamRestored(
+                            channelData.value().getChannel(),
+                            channelData.value().getTeam(),
+                            turnContext
+                        );
+
+                    case "teamUnarchived":
+                        return onTeamsTeamUnarchived(
                             channelData.value().getChannel(),
                             channelData.value().getTeam(),
                             turnContext
@@ -550,7 +585,82 @@ public class TeamsActivityHandler extends ActivityHandler {
         return CompletableFuture.completedFuture(null);
     }
 
+    /**
+     * Invoked when a Team Archived event activity is received from the connector.
+     * Team Archived correspond to the user archiving a team.
+     *
+     * @param turnContext The current TurnContext.
+     * @return A task that represents the work queued to execute.
+     */
+    protected CompletableFuture<Void> onTeamsTeamArchived(
+        ChannelInfo channelInfo,
+        TeamInfo teamInfo,
+        TurnContext turnContext
+    ) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    /**
+     * Invoked when a Team Deleted event activity is received from the connector.
+     * Team Deleted correspond to the user deleting a team.
+     *
+     * @param turnContext The current TurnContext.
+     * @return A task that represents the work queued to execute.
+     */
+    protected CompletableFuture<Void> onTeamsTeamDeleted(
+        ChannelInfo channelInfo,
+        TeamInfo teamInfo,
+        TurnContext turnContext
+    ) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    /**
+     * Invoked when a Team Hard Deleted event activity is received from the connector.
+     * Team Hard Deleted correspond to the user hard-deleting a team.
+     *
+     * @param turnContext The current TurnContext.
+     * @return A task that represents the work queued to execute.
+     */
+    protected CompletableFuture<Void> onTeamsTeamHardDeleted(
+        ChannelInfo channelInfo,
+        TeamInfo teamInfo,
+        TurnContext turnContext
+    ) {
+        return CompletableFuture.completedFuture(null);
+    }
+
     protected CompletableFuture<Void> onTeamsTeamRenamed(
+        ChannelInfo channelInfo,
+        TeamInfo teamInfo,
+        TurnContext turnContext
+    ) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    /**
+     * Invoked when a Team Restored event activity is received from the connector.
+     * Team Restored correspond to the user restoring a team.
+     *
+     * @param turnContext The current TurnContext.
+     * @return A task that represents the work queued to execute.
+     */
+    protected CompletableFuture<Void> onTeamsTeamRestored(
+        ChannelInfo channelInfo,
+        TeamInfo teamInfo,
+        TurnContext turnContext
+    ) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    /**
+     * Invoked when a Team Unarchived event activity is received from the connector.
+     * Team Unarchived correspond to the user unarchiving a team.
+     *
+     * @param turnContext The current TurnContext.
+     * @return A task that represents the work queued to execute.
+     */
+    protected CompletableFuture<Void> onTeamsTeamUnarchived(
         ChannelInfo channelInfo,
         TeamInfo teamInfo,
         TurnContext turnContext

--- a/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/teams/TeamsActivityHandlerTests.java
+++ b/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/teams/TeamsActivityHandlerTests.java
@@ -338,6 +338,121 @@ public class TeamsActivityHandlerTests {
     }
 
     @Test
+    public void TestConversationUpdateTeamsTeamArchived() {
+        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE) {
+            {
+                setChannelData(new TeamsChannelData() {
+                    {
+                        setEventType("teamArchived");
+                    }
+                });
+                setChannelId(Channels.MSTEAMS);
+            }
+        };
+
+        TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
+
+        TestActivityHandler bot = new TestActivityHandler();
+        bot.onTurn(turnContext).join();
+
+        Assert.assertEquals(2, bot.record.size());
+        Assert.assertEquals("onConversationUpdateActivity", bot.record.get(0));
+        Assert.assertEquals("onTeamsTeamArchived", bot.record.get(1));
+    }
+
+    @Test
+    public void TestConversationUpdateTeamsTeamDeleted() {
+        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE) {
+            {
+                setChannelData(new TeamsChannelData() {
+                    {
+                        setEventType("teamDeleted");
+                    }
+                });
+                setChannelId(Channels.MSTEAMS);
+            }
+        };
+
+        TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
+
+        TestActivityHandler bot = new TestActivityHandler();
+        bot.onTurn(turnContext).join();
+
+        Assert.assertEquals(2, bot.record.size());
+        Assert.assertEquals("onConversationUpdateActivity", bot.record.get(0));
+        Assert.assertEquals("onTeamsTeamDeleted", bot.record.get(1));
+    }
+
+    @Test
+    public void TestConversationUpdateTeamsTeamHardDeleted() {
+        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE) {
+            {
+                setChannelData(new TeamsChannelData() {
+                    {
+                        setEventType("teamHardDeleted");
+                    }
+                });
+                setChannelId(Channels.MSTEAMS);
+            }
+        };
+
+        TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
+
+        TestActivityHandler bot = new TestActivityHandler();
+        bot.onTurn(turnContext).join();
+
+        Assert.assertEquals(2, bot.record.size());
+        Assert.assertEquals("onConversationUpdateActivity", bot.record.get(0));
+        Assert.assertEquals("onTeamsTeamHardDeleted", bot.record.get(1));
+    }
+
+    @Test
+    public void TestConversationUpdateTeamsTeamRestored() {
+        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE) {
+            {
+                setChannelData(new TeamsChannelData() {
+                    {
+                        setEventType("teamRestored");
+                    }
+                });
+                setChannelId(Channels.MSTEAMS);
+            }
+        };
+
+        TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
+
+        TestActivityHandler bot = new TestActivityHandler();
+        bot.onTurn(turnContext).join();
+
+        Assert.assertEquals(2, bot.record.size());
+        Assert.assertEquals("onConversationUpdateActivity", bot.record.get(0));
+        Assert.assertEquals("onTeamsTeamRestored", bot.record.get(1));
+    }
+
+    @Test
+    public void TestConversationUpdateTeamsTeamUnarchived() {
+        Activity activity = new Activity(ActivityTypes.CONVERSATION_UPDATE) {
+            {
+                setChannelData(new TeamsChannelData() {
+                    {
+                        setEventType("teamUnarchived");
+                    }
+                });
+                setChannelId(Channels.MSTEAMS);
+            }
+        };
+
+        TurnContext turnContext = new TurnContextImpl(new NotImplementedAdapter(), activity);
+
+        TestActivityHandler bot = new TestActivityHandler();
+        bot.onTurn(turnContext).join();
+
+        Assert.assertEquals(2, bot.record.size());
+        Assert.assertEquals("onConversationUpdateActivity", bot.record.get(0));
+        Assert.assertEquals("onTeamsTeamUnarchived", bot.record.get(1));
+    }
+
+    @Test
     public void TestFileConsentAccept() {
         Activity activity = new Activity(ActivityTypes.INVOKE) {
             {
@@ -1170,6 +1285,56 @@ public class TeamsActivityHandlerTests {
         ) {
             record.add("onTeamsTeamRenamed");
             return super.onTeamsTeamRenamed(channelInfo, teamInfo, turnContext);
+        }
+
+        @Override
+        protected CompletableFuture<Void> onTeamsTeamArchived(
+            ChannelInfo channelInfo,
+            TeamInfo teamInfo,
+            TurnContext turnContext
+        ) {
+            record.add("onTeamsTeamArchived");
+            return super.onTeamsTeamArchived(channelInfo, teamInfo, turnContext);
+        }
+
+        @Override
+        protected CompletableFuture<Void> onTeamsTeamDeleted(
+            ChannelInfo channelInfo,
+            TeamInfo teamInfo,
+            TurnContext turnContext
+        ) {
+            record.add("onTeamsTeamDeleted");
+            return super.onTeamsTeamDeleted(channelInfo, teamInfo, turnContext);
+        }
+
+        @Override
+        protected CompletableFuture<Void> onTeamsTeamHardDeleted(
+            ChannelInfo channelInfo,
+            TeamInfo teamInfo,
+            TurnContext turnContext
+        ) {
+            record.add("onTeamsTeamHardDeleted");
+            return super.onTeamsTeamHardDeleted(channelInfo, teamInfo, turnContext);
+        }
+
+        @Override
+        protected CompletableFuture<Void> onTeamsTeamRestored(
+            ChannelInfo channelInfo,
+            TeamInfo teamInfo,
+            TurnContext turnContext
+        ) {
+            record.add("onTeamsTeamRestored");
+            return super.onTeamsTeamRestored(channelInfo, teamInfo, turnContext);
+        }
+
+        @Override
+        protected CompletableFuture<Void> onTeamsTeamUnarchived(
+            ChannelInfo channelInfo,
+            TeamInfo teamInfo,
+            TurnContext turnContext
+        ) {
+            record.add("onTeamsTeamUnarchived");
+            return super.onTeamsTeamUnarchived(channelInfo, teamInfo, turnContext);
         }
     }
 


### PR DESCRIPTION
Fixes # 611

## Description
- Add the following events to the [TeamsActivityHandler](https://github.com/microsoft/botbuilder-java/blob/master/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/teams/TeamsActivityHandler.java) class.
  - teamArchived
  - teamDeleted
  - teamHardDeleted
  - teamRestored
  - teamUnarchived

**Note:** These changes can't be tested using MS-Teams until the implementation to use these events is done.

## Specific Changes
- Updated [TeamsActivityHandler](https://github.com/microsoft/botbuilder-java/blob/master/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/teams/TeamsActivityHandler.java) class to add the following methods:
  - _onTeamsTeamArchived_.
  - _onTeamsTeamDeleted_.
  - _onTeamsTeamHardDeleted_.
  - _onTeamsTeamRestored_.
  - _onTeamsTeamUnarchived_.

- Updated [TeamsActivityHandlerTests](https://github.com/microsoft/botbuilder-java/blob/master/libraries/bot-builder/src/test/java/com/microsoft/bot/builder/teams/TeamsActivityHandlerTests.java) class to add the unit tests for the previous methods.

## Testing
The next image shows the new tests passing:
![image](https://user-images.githubusercontent.com/44245136/86290902-9837cf80-bbc4-11ea-9bcc-c826e18a2192.png)
