### PR TITLE
[Bot-AI-LUIS-V3] Fix disparities

### DIFF
--- a/libraries/bot-ai-luis-v3/pom.xml
+++ b/libraries/bot-ai-luis-v3/pom.xml
@@ -66,10 +66,6 @@
     </dependency>
     <dependency>
       <groupId>com.microsoft.bot</groupId>
-      <artifactId>bot-applicationinsights</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.microsoft.bot</groupId>
       <artifactId>bot-dialogs</artifactId>
     </dependency>
     <dependency>

--- a/libraries/bot-ai-luis-v3/src/main/java/com/microsoft/bot/ai/luis/DynamicList.java
+++ b/libraries/bot-ai-luis-v3/src/main/java/com/microsoft/bot/ai/luis/DynamicList.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 /**
  * Request Body element to use when passing Dynamic lists to the Luis Service
- * call.
+ * call. Defines an extension for a list entity.
  *
  */
 public class DynamicList {
@@ -21,7 +21,7 @@ public class DynamicList {
 
     /**
      * Initializes a new instance of the DynamicList class.
-     * 
+     *
      * @param entity       Entity field.
      * @param requestLists List Elements to use when querying Luis Service.
      */
@@ -37,36 +37,36 @@ public class DynamicList {
     private List<ListElement> list;
 
     /**
-     * Gets the entity.
-     * 
-     * @return Entity name.
+     * Gets the name of the list entity to extend.
+     *
+     * @return The name of the list entity to extend.
      */
     public String getEntity() {
         return entity;
     }
 
     /**
-     * Sets the entity name.
-     * 
-     * @param entity entity name.
+     * Sets the name of the list entity to extend.
+     *
+     * @param entity The name of the list entity to extend.
      */
     public void setEntity(String entity) {
         this.entity = entity;
     }
 
     /**
-     * Gets the List.
-     * 
-     * @return Element list of the Dynamic List.
+     * Gets the lists to append on the extended list entity.
+     *
+     * @return The lists to append on the extended list entity.
      */
     public List<ListElement> getList() {
         return list;
     }
 
     /**
-     * Sets the List.
-     * 
-     * @param list Element list of the Dynamic List.
+     * Sets the lists to append on the extended list entity.
+     *
+     * @param list The lists to append on the extended list entity.
      */
     public void setList(List<ListElement> list) {
         this.list = list;
@@ -74,13 +74,13 @@ public class DynamicList {
 
     /**
      * Validate the object.
-     * 
+     *
      * @throws IllegalArgumentException on null or invalid values.
      */
     public void validate() throws IllegalArgumentException {
         // Required: ListEntityName, RequestLists
         if (entity == null || list == null) {
-            throw new IllegalArgumentException("ExternalEntity requires an EntityName and EntityLength > 0");
+            throw new IllegalArgumentException("DynamicList requires listEntityName and requestsLists to be defined.");
         }
 
         for (ListElement e : list) {

--- a/libraries/bot-ai-luis-v3/src/main/java/com/microsoft/bot/ai/luis/ExternalEntity.java
+++ b/libraries/bot-ai-luis-v3/src/main/java/com/microsoft/bot/ai/luis/ExternalEntity.java
@@ -8,7 +8,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  * Request Body element to use when passing External Entities to the Luis
- * Service call.
+ * Service call. Defines a user predicted entity that extends an already
+ * existing one.
  *
  */
 public class ExternalEntity {
@@ -21,7 +22,7 @@ public class ExternalEntity {
 
     /**
      * Initializes a new instance of ExternalEntity.
-     * 
+     *
      * @param entity     name of the entity to extend.
      * @param start      start character index of the predicted entity.
      * @param length     length of the predicted entity.
@@ -49,8 +50,8 @@ public class ExternalEntity {
 
     /**
      * Gets the start character index of the predicted entity.
-     * 
-     * @return start character index of the predicted entity.
+     *
+     * @return The start character index of the predicted entity.
      */
     public int getStart() {
         return start;
@@ -58,8 +59,8 @@ public class ExternalEntity {
 
     /**
      * Sets the start character index of the predicted entity.
-     * 
-     * @param start character index of the predicted entity.
+     *
+     * @param start The start character index of the predicted entity.
      */
     public void setStart(int start) {
         this.start = start;
@@ -67,8 +68,8 @@ public class ExternalEntity {
 
     /**
      * Gets the name of the entity to extend.
-     * 
-     * @return name of the entity to extend.
+     *
+     * @return The name of the entity to extend.
      */
     public String getEntity() {
         return entity;
@@ -76,8 +77,8 @@ public class ExternalEntity {
 
     /**
      * Sets the name of the entity to extend.
-     * 
-     * @param entity name of the entity to extend.
+     *
+     * @param entity The name of the entity to extend.
      */
     public void setEntity(String entity) {
         this.entity = entity;
@@ -85,8 +86,8 @@ public class ExternalEntity {
 
     /**
      * Gets the length of the predicted entity.
-     * 
-     * @return length of the predicted entity.
+     *
+     * @return The length of the predicted entity.
      */
     public int getLength() {
         return length;
@@ -94,8 +95,8 @@ public class ExternalEntity {
 
     /**
      * Sets the length of the predicted entity.
-     * 
-     * @param length of the predicted entity.
+     *
+     * @param length The length of the predicted entity.
      */
     public void setLength(int length) {
         this.length = length;
@@ -103,17 +104,19 @@ public class ExternalEntity {
 
     /**
      * Gets a user supplied custom resolution to return as the entity's prediction.
-     * 
-     * @return custom resolution to return as the entity's prediction.
+     *
+     * @return A user supplied custom resolution to return as the entity's
+     *         prediction.
      */
     public JsonNode getResolution() {
         return resolution;
     }
 
     /**
-     * Sets External entities to be recognized in query.
-     * 
-     * @param resolution custom resolution to return as the entity's prediction.
+     * Sets a user supplied custom resolution to return as the entity's prediction.
+     *
+     * @param resolution A user supplied custom resolution to return as the entity's
+     *          prediction.
      */
     public void setResolution(JsonNode resolution) {
         this.resolution = resolution;
@@ -121,7 +124,7 @@ public class ExternalEntity {
 
     /**
      * Validate the object.
-     * 
+     *
      * @throws IllegalArgumentException on null or invalid values
      */
     public void validate() throws IllegalArgumentException {

--- a/libraries/bot-ai-luis-v3/src/main/java/com/microsoft/bot/ai/luis/ExternalEntity.java
+++ b/libraries/bot-ai-luis-v3/src/main/java/com/microsoft/bot/ai/luis/ExternalEntity.java
@@ -43,7 +43,7 @@ public class ExternalEntity {
     private int start;
 
     @JsonProperty(value = "entityLength")
-    private int length = -1;
+    private int length;
 
     @JsonProperty(value = "resolution")
     private JsonNode resolution;
@@ -128,7 +128,7 @@ public class ExternalEntity {
      * @throws IllegalArgumentException on null or invalid values
      */
     public void validate() throws IllegalArgumentException {
-        if (entity == null || length == -1) {
+        if (entity == null || length == 0) {
             throw new IllegalArgumentException("ExternalEntity requires an EntityName and EntityLength > 0");
         }
     }

--- a/libraries/bot-ai-luis-v3/src/main/java/com/microsoft/bot/ai/luis/ListElement.java
+++ b/libraries/bot-ai-luis-v3/src/main/java/com/microsoft/bot/ai/luis/ListElement.java
@@ -9,7 +9,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
 /**
- * List Element for Dynamic Lists.
+ * List Element for Dynamic Lists. Defines a sub-list to append to an existing
+ * list entity.
  *
  */
 public class ListElement {
@@ -22,7 +23,7 @@ public class ListElement {
 
     /**
      * Initializes a new instance of the ListElement class.
-     * 
+     *
      * @param canonicalForm The canonical form of the sub-list.
      * @param synonyms      The synonyms of the canonical form.
      */
@@ -46,7 +47,7 @@ public class ListElement {
 
     /**
      * Gets the canonical form of the sub-list.
-     * 
+     *
      * @return String canonical form of the sub-list.
      */
     public String getCanonicalForm() {
@@ -55,7 +56,7 @@ public class ListElement {
 
     /**
      * Sets the canonical form of the sub-list.
-     * 
+     *
      * @param canonicalForm the canonical form of the sub-list.
      */
     public void setCanonicalForm(String canonicalForm) {
@@ -64,7 +65,7 @@ public class ListElement {
 
     /**
      * Gets the synonyms of the canonical form.
-     * 
+     *
      * @return the synonyms List of the canonical form.
      */
     public List<String> getSynonyms() {
@@ -73,7 +74,7 @@ public class ListElement {
 
     /**
      * Sets the synonyms of the canonical form.
-     * 
+     *
      * @param synonyms List of synonyms of the canonical form.
      */
     public void setSynonyms(List<String> synonyms) {
@@ -82,7 +83,7 @@ public class ListElement {
 
     /**
      * Validate the object.
-     * 
+     *
      * @throws IllegalArgumentException if canonicalForm is null.
      */
     public void validate() throws IllegalArgumentException {

--- a/libraries/bot-ai-luis-v3/src/main/java/com/microsoft/bot/ai/luis/LuisApplication.java
+++ b/libraries/bot-ai-luis-v3/src/main/java/com/microsoft/bot/ai/luis/LuisApplication.java
@@ -9,37 +9,39 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.UUID;
 
+import org.apache.commons.lang3.StringUtils;
+
 /**
  * Luis Application representation with information necessary to query the
- * specific Luis Application.
+ * specific Luis Application. Data describing a LUIS application.
  *
  */
 public class LuisApplication {
 
     /**
-     * Luis application ID.
+     * LUIS application ID.
      */
     private String applicationId;
 
     /**
-     * Luis subscription or endpoint key.
+     * LUIS subscription or endpoint key.
      */
     private String endpointKey;
 
     /**
-     * Luis subscription or endpoint key.
+     * LUIS endpoint like https://westus.api.cognitive.microsoft.com.
      */
     private String endpoint;
 
     /**
-     * Luis endpoint like https://westus.api.cognitive.microsoft.com.
+     * Initializes a new instance of the Luis Application class.
      */
     public LuisApplication() {
     }
 
     /**
      * Initializes a new instance of the Luis Application class.
-     * 
+     *
      * @param applicationId Luis Application ID to query
      * @param endpointKey   LUIS subscription or endpoint key.
      * @param endpoint      LUIS endpoint to use like
@@ -51,7 +53,7 @@ public class LuisApplication {
 
     /**
      * Initializes a new instance of the Luis Application class.
-     * 
+     *
      * @param applicationEndpoint LUIS application query endpoint containing
      *                            subscription key and application id as part of the
      *                            url.
@@ -62,7 +64,7 @@ public class LuisApplication {
 
     /**
      * Sets Luis application ID to query.
-     * 
+     *
      * @param applicationId Luis application ID to query.
      */
     public void setApplicationId(String applicationId) {
@@ -70,9 +72,9 @@ public class LuisApplication {
     }
 
     /**
-     * Gets Luis application ID.
-     * 
-     * @return applicationId.
+     * Gets LUIS application ID.
+     *
+     * @return LUIS application ID.
      */
     public String getApplicationId() {
         return applicationId;
@@ -80,7 +82,7 @@ public class LuisApplication {
 
     /**
      * Sets the LUIS subscription or endpoint key.
-     * 
+     *
      * @param endpointKey LUIS subscription or endpoint key.
      */
     public void setEndpointKey(String endpointKey) {
@@ -89,17 +91,17 @@ public class LuisApplication {
 
     /**
      * Gets the LUIS subscription or endpoint key.
-     * 
-     * @return endpointKey.
+     *
+     * @return LUIS subscription or endpoint key.
      */
     public String getEndpointKey() {
         return endpointKey;
     }
 
     /**
-     * Sets Luis endpoint like https://westus.api.cognitive.microsoft.com.
-     * 
-     * @param endpoint endpoint like https://westus.api.cognitive.microsoft.com.
+     * Sets LUIS endpoint like https://westus.api.cognitive.microsoft.com.
+     *
+     * @param endpoint LUIS endpoint where application is hosted.
      */
     public void setEndpoint(String endpoint) {
         this.endpoint = endpoint;
@@ -107,8 +109,8 @@ public class LuisApplication {
 
     /**
      * Gets the LUIS endpoint where application is hosted.
-     * 
-     * @return endpoint.
+     *
+     * @return LUIS endpoint where application is hosted.
      */
     public String getEndpoint() {
         return endpoint;
@@ -156,34 +158,25 @@ public class LuisApplication {
             }
         } catch (MalformedURLException e) {
             throw new IllegalArgumentException(
-                String.format("Unable to create the LUIS endpoint with the given %s.", applicationEndpoint)
-            );
+                    String.format("Unable to create the LUIS endpoint with the given %s.", applicationEndpoint));
         }
 
         if (appId.isEmpty()) {
             throw new IllegalArgumentException(
-                String.format("Could not find application Id in %s", applicationEndpoint)
-            );
+                    String.format("Could not find application Id in %s", applicationEndpoint));
         }
 
         try {
-            String endpointKeyParsed = HttpUrl.parse(applicationEndpoint)
-                .queryParameterValues("subscription-key")
-                .stream()
-                .findFirst()
-                .orElse("");
+            String endpointKeyParsed = HttpUrl.parse(applicationEndpoint).queryParameterValues("subscription-key")
+                    .stream().findFirst().orElse("");
 
-            String endpointPared = String.format(
-                "%s://%s",
-                new URL(applicationEndpoint).getProtocol(),
-                new URL(applicationEndpoint).toURI().getHost()
-            );
+            String endpointPared = String.format("%s://%s", new URL(applicationEndpoint).getProtocol(),
+                    new URL(applicationEndpoint).toURI().getHost());
 
             setLuisApplication(appId, endpointKeyParsed, endpointPared);
         } catch (URISyntaxException | MalformedURLException e) {
             throw new IllegalArgumentException(
-                String.format("Unable to create the LUIS endpoint with the given %s.", applicationEndpoint)
-            );
+                    String.format("Unable to create the LUIS endpoint with the given %s.", applicationEndpoint));
         }
 
     }

--- a/libraries/bot-ai-luis-v3/src/main/java/com/microsoft/bot/ai/luis/LuisApplication.java
+++ b/libraries/bot-ai-luis-v3/src/main/java/com/microsoft/bot/ai/luis/LuisApplication.java
@@ -129,7 +129,7 @@ public class LuisApplication {
             throw new IllegalArgumentException(String.format("%s is not a valid LUIS subscription key.", endpointKey));
         }
 
-        if (endpoint == null || endpoint.isEmpty()) {
+        if (StringUtils.isBlank(endpoint)) {
             endpoint = "https://westus.api.cognitive.microsoft.com";
         }
 

--- a/libraries/bot-ai-luis-v3/src/main/java/com/microsoft/bot/ai/luis/LuisRecognizer.java
+++ b/libraries/bot-ai-luis-v3/src/main/java/com/microsoft/bot/ai/luis/LuisRecognizer.java
@@ -12,6 +12,8 @@ import com.microsoft.bot.builder.TurnContext;
 import com.microsoft.bot.dialogs.DialogContext;
 import com.microsoft.bot.schema.Activity;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -22,8 +24,8 @@ import java.util.concurrent.CompletableFuture;
 
 /**
  * Luis Recognizer class to query the LUIS Service using the configuration set
- * by the LuisRecognizeroptions.
- *
+ * by the LuisRecognizeroptions. A LUIS based implementation of
+ * TelemetryRecognizer.
  */
 public class LuisRecognizer extends TelemetryRecognizer {
     /**
@@ -32,9 +34,9 @@ public class LuisRecognizer extends TelemetryRecognizer {
     private LuisRecognizerOptions luisRecognizerOptions;
 
     /**
-     * Initializes a new instance of the Luis Recognizer .
-     * 
-     * @param recognizerOptions Luis Recognizer options to use when calling th LUIS
+     * Initializes a new instance of the Luis Recognizer.
+     *
+     * @param recognizerOptions Luis Recognizer options to use when calling the LUIS
      *                          Service.
      * @throws IllegalArgumentException if null is passed as recognizerOptions.
      */
@@ -44,17 +46,14 @@ public class LuisRecognizer extends TelemetryRecognizer {
         }
 
         this.luisRecognizerOptions = recognizerOptions;
+        this.setTelemetryClient(recognizerOptions.getTelemetryClient() != null ? recognizerOptions.getTelemetryClient()
+                : new NullBotTelemetryClient());
         this.setLogPersonalInformation(recognizerOptions.isLogPersonalInformation());
-        this.setTelemetryClient(
-            recognizerOptions.getTelemetryClient() != null
-                ? recognizerOptions.getTelemetryClient()
-                : new NullBotTelemetryClient()
-        );
     }
 
     /**
      * Returns the name of the top scoring intent from a set of LUIS results.
-     * 
+     *
      * @param results The Recognizer Result with the list of Intents to filter.
      *                Defaults to a value of "None" and a min score value of `0.0`
      * @return The top scoring intent name.
@@ -65,7 +64,7 @@ public class LuisRecognizer extends TelemetryRecognizer {
 
     /**
      * Returns the name of the top scoring intent from a set of LUIS results.
-     * 
+     *
      * @param results       The Recognizer Result with the list of Intents to filter
      * @param defaultIntent Intent name to return should a top intent be found.
      *                      Defaults to a value of "None" and a min score value of
@@ -78,7 +77,7 @@ public class LuisRecognizer extends TelemetryRecognizer {
 
     /**
      * Returns the name of the top scoring intent from a set of LUIS results.
-     * 
+     *
      * @param results  The Recognizer Result with the list of Intents to filter.
      * @param minScore Minimum score needed for an intent to be considered as a top
      *                 intent.
@@ -90,7 +89,7 @@ public class LuisRecognizer extends TelemetryRecognizer {
 
     /**
      * Returns the name of the top scoring intent from a set of LUIS results.
-     * 
+     *
      * @param results       The Recognizer Result with the list of Intents to filter
      * @param defaultIntent Intent name to return should a top intent be found.
      *                      Defaults to a value of "None
@@ -118,12 +117,12 @@ public class LuisRecognizer extends TelemetryRecognizer {
             }
         }
 
-        return topIntent != null && !topIntent.equals("") ? topIntent : defaultIntent;
+        return StringUtils.isNotBlank(topIntent) ? topIntent : defaultIntent;
     }
 
     /**
      * Return results of the analysis (Suggested actions and intents).
-     * 
+     *
      * @param turnContext Context object containing information for a single turn of
      *                    conversation with a user.
      * @return The LUIS results of the analysis of the current message text in the
@@ -136,7 +135,7 @@ public class LuisRecognizer extends TelemetryRecognizer {
 
     /**
      * Return results of the analysis (Suggested actions and intents).
-     * 
+     *
      * @param dialogContext Context object containing information for a single turn
      *                      of conversation with a user.
      * @param activity      Activity to recognize.
@@ -150,7 +149,7 @@ public class LuisRecognizer extends TelemetryRecognizer {
     /**
      * Runs an utterance through a recognizer and returns a strongly-typed
      * recognizer result.
-     * 
+     *
      * @param turnContext Context object containing information for a single turn of
      *                    conversation with a user.
      * @param <T>         type of result.
@@ -161,13 +160,13 @@ public class LuisRecognizer extends TelemetryRecognizer {
      */
     public <T extends RecognizerConvert> CompletableFuture<T> recognize(TurnContext turnContext, Class<T> c) {
         return recognizeInternal(turnContext, null, null, null)
-            .thenApply(recognizerResult -> convertRecognizerResult(recognizerResult, c));
+                .thenApply(recognizerResult -> convertRecognizerResult(recognizerResult, c));
     }
 
     /**
      * Runs an utterance through a recognizer and returns a strongly-typed
      * recognizer result.
-     * 
+     *
      * @param dialogContext Context object containing information for a single turn
      *                      of conversation with a user.
      * @param activity      Activity to recognize.
@@ -177,18 +176,15 @@ public class LuisRecognizer extends TelemetryRecognizer {
      * @return The LUIS results of the analysis of the current message text in the
      *         current turn's context activity.
      */
-    public <T extends RecognizerConvert> CompletableFuture<T> recognize(
-        DialogContext dialogContext,
-        Activity activity,
-        Class<T> c
-    ) {
+    public <T extends RecognizerConvert> CompletableFuture<T> recognize(DialogContext dialogContext, Activity activity,
+            Class<T> c) {
         return recognizeInternal(dialogContext, activity, null, null, null)
-            .thenApply(recognizerResult -> convertRecognizerResult(recognizerResult, c));
+                .thenApply(recognizerResult -> convertRecognizerResult(recognizerResult, c));
     }
 
     /**
      * Return results of the analysis (Suggested actions and intents).
-     * 
+     *
      * @param turnContext         Context object containing information for a single
      *                            turn of conversation with a user.
      * @param telemetryProperties Additional properties to be logged to telemetry
@@ -199,17 +195,14 @@ public class LuisRecognizer extends TelemetryRecognizer {
      *         current turn's context activity.
      */
     @Override
-    public CompletableFuture<RecognizerResult> recognize(
-        TurnContext turnContext,
-        Map<String, String> telemetryProperties,
-        Map<String, Double> telemetryMetrics
-    ) {
+    public CompletableFuture<RecognizerResult> recognize(TurnContext turnContext,
+            Map<String, String> telemetryProperties, Map<String, Double> telemetryMetrics) {
         return recognizeInternal(turnContext, null, telemetryProperties, telemetryMetrics);
     }
 
     /**
      * Return results of the analysis (Suggested actions and intents).
-     * 
+     *
      * @param dialogContext       Context object containing information for a single
      *                            turn of conversation with a user.
      * @param activity            Activity to recognize.
@@ -220,19 +213,15 @@ public class LuisRecognizer extends TelemetryRecognizer {
      * @return The LUIS results of the analysis of the current message text in the
      *         current turn's context activity.
      */
-    public CompletableFuture<RecognizerResult> recognize(
-        DialogContext dialogContext,
-        Activity activity,
-        Map<String, String> telemetryProperties,
-        Map<String, Double> telemetryMetrics
-    ) {
+    public CompletableFuture<RecognizerResult> recognize(DialogContext dialogContext, Activity activity,
+            Map<String, String> telemetryProperties, Map<String, Double> telemetryMetrics) {
         return recognizeInternal(dialogContext, activity, null, telemetryProperties, telemetryMetrics);
     }
 
     /**
      * Runs an utterance through a recognizer and returns a strongly-typed
      * recognizer result.
-     * 
+     *
      * @param turnContext         Context object containing information for a single
      *                            turn of conversation with a user.
      * @param telemetryProperties Additional properties to be logged to telemetry
@@ -245,20 +234,16 @@ public class LuisRecognizer extends TelemetryRecognizer {
      * @return The LUIS results of the analysis of the current message text in the
      *         current turn's context activity.
      */
-    public <T extends RecognizerConvert> CompletableFuture<T> recognize(
-        TurnContext turnContext,
-        Map<String, String> telemetryProperties,
-        Map<String, Double> telemetryMetrics,
-        Class<T> c
-    ) {
+    public <T extends RecognizerConvert> CompletableFuture<T> recognize(TurnContext turnContext,
+            Map<String, String> telemetryProperties, Map<String, Double> telemetryMetrics, Class<T> c) {
         return recognizeInternal(turnContext, null, telemetryProperties, telemetryMetrics)
-            .thenApply(recognizerResult -> convertRecognizerResult(recognizerResult, c));
+                .thenApply(recognizerResult -> convertRecognizerResult(recognizerResult, c));
     }
 
     /**
      * Runs an utterance through a recognizer and returns a strongly-typed
      * recognizer result.
-     * 
+     *
      * @param dialogContext       Context object containing information for a single
      *                            turn of conversation with a user.
      * @param activity            Activity to recognize.
@@ -272,20 +257,15 @@ public class LuisRecognizer extends TelemetryRecognizer {
      * @return The LUIS results of the analysis of the current message text in the
      *         current turn's context activity.
      */
-    public <T extends RecognizerConvert> CompletableFuture<T> recognize(
-        DialogContext dialogContext,
-        Activity activity,
-        Map<String, String> telemetryProperties,
-        Map<String, Double> telemetryMetrics,
-        Class<T> c
-    ) {
+    public <T extends RecognizerConvert> CompletableFuture<T> recognize(DialogContext dialogContext, Activity activity,
+            Map<String, String> telemetryProperties, Map<String, Double> telemetryMetrics, Class<T> c) {
         return recognizeInternal(dialogContext, activity, null, telemetryProperties, telemetryMetrics)
-            .thenApply(recognizerResult -> convertRecognizerResult(recognizerResult, c));
+                .thenApply(recognizerResult -> convertRecognizerResult(recognizerResult, c));
     }
 
     /**
      * Return results of the analysis (Suggested actions and intents).
-     * 
+     *
      * @param turnContext       Context object containing information for a single
      *                          turn of conversation with a user.
      * @param recognizerOptions A LuisRecognizerOptions instance to be used by the
@@ -294,16 +274,14 @@ public class LuisRecognizer extends TelemetryRecognizer {
      * @return The LUIS results of the analysis of the current message text in the
      *         current turn's context activity.
      */
-    public CompletableFuture<RecognizerResult> recognize(
-        TurnContext turnContext,
-        LuisRecognizerOptions recognizerOptions
-    ) {
+    public CompletableFuture<RecognizerResult> recognize(TurnContext turnContext,
+            LuisRecognizerOptions recognizerOptions) {
         return recognizeInternal(turnContext, recognizerOptions, null, null);
     }
 
     /**
      * Return results of the analysis (Suggested actions and intents).
-     * 
+     *
      * @param dialogContext     Context object containing information for a single
      *                          turn of conversation with a user.
      * @param activity          Activity to recognize.
@@ -313,18 +291,15 @@ public class LuisRecognizer extends TelemetryRecognizer {
      * @return The LUIS results of the analysis of the current message text in the
      *         current turn's context activity.
      */
-    public CompletableFuture<RecognizerResult> recognize(
-        DialogContext dialogContext,
-        Activity activity,
-        LuisRecognizerOptions recognizerOptions
-    ) {
+    public CompletableFuture<RecognizerResult> recognize(DialogContext dialogContext, Activity activity,
+            LuisRecognizerOptions recognizerOptions) {
         return recognizeInternal(dialogContext, activity, recognizerOptions, null, null);
     }
 
     /**
      * Runs an utterance through a recognizer and returns a strongly-typed
      * recognizer result.
-     * 
+     *
      * @param turnContext       Context object containing information for a single
      *                          turn of conversation with a user.
      * @param recognizerOptions A LuisRecognizerOptions instance to be used by the
@@ -336,19 +311,16 @@ public class LuisRecognizer extends TelemetryRecognizer {
      * @return The LUIS results of the analysis of the current message text in the
      *         current turn's context activity.
      */
-    public <T extends RecognizerConvert> CompletableFuture<T> recognize(
-        TurnContext turnContext,
-        LuisRecognizerOptions recognizerOptions,
-        Class<T> c
-    ) {
+    public <T extends RecognizerConvert> CompletableFuture<T> recognize(TurnContext turnContext,
+            LuisRecognizerOptions recognizerOptions, Class<T> c) {
         return recognizeInternal(turnContext, recognizerOptions, null, null)
-            .thenApply(recognizerResult -> convertRecognizerResult(recognizerResult, c));
+                .thenApply(recognizerResult -> convertRecognizerResult(recognizerResult, c));
     }
 
     /**
      * Runs an utterance through a recognizer and returns a strongly-typed
      * recognizer result.
-     * 
+     *
      * @param dialogContext     Context object containing information for a single
      *                          turn of conversation with a user.
      * @param activity          Activity to recognize.
@@ -361,19 +333,15 @@ public class LuisRecognizer extends TelemetryRecognizer {
      * @return The LUIS results of the analysis of the current message text in the
      *         current turn's context activity.
      */
-    public <T extends RecognizerConvert> CompletableFuture<T> recognize(
-        DialogContext dialogContext,
-        Activity activity,
-        LuisRecognizerOptions recognizerOptions,
-        Class<T> c
-    ) {
+    public <T extends RecognizerConvert> CompletableFuture<T> recognize(DialogContext dialogContext, Activity activity,
+            LuisRecognizerOptions recognizerOptions, Class<T> c) {
         return recognizeInternal(dialogContext, activity, recognizerOptions, null, null)
-            .thenApply(recognizerResult -> convertRecognizerResult(recognizerResult, c));
+                .thenApply(recognizerResult -> convertRecognizerResult(recognizerResult, c));
     }
 
     /**
      * Return results of the analysis (Suggested actions and intents).
-     * 
+     *
      * @param turnContext         Context object containing information for a single
      *                            turn of conversation with a user.
      * @param recognizerOptions   LuisRecognizerOptions instance to be used by the
@@ -386,18 +354,15 @@ public class LuisRecognizer extends TelemetryRecognizer {
      * @return The LUIS results of the analysis of the current message text in the
      *         current turn's context activity.
      */
-    public CompletableFuture<RecognizerResult> recognize(
-        TurnContext turnContext,
-        LuisRecognizerOptions recognizerOptions,
-        Map<String, String> telemetryProperties,
-        Map<String, Double> telemetryMetrics
-    ) {
+    public CompletableFuture<RecognizerResult> recognize(TurnContext turnContext,
+            LuisRecognizerOptions recognizerOptions, Map<String, String> telemetryProperties,
+            Map<String, Double> telemetryMetrics) {
         return recognizeInternal(turnContext, recognizerOptions, telemetryProperties, telemetryMetrics);
     }
 
     /**
      * Return results of the analysis (Suggested actions and intents).
-     * 
+     *
      * @param dialogContext       Context object containing information for a single
      *                            turn of conversation with a user.
      * @param activity            Activity to recognize.
@@ -411,20 +376,16 @@ public class LuisRecognizer extends TelemetryRecognizer {
      * @return The LUIS results of the analysis of the current message text in the
      *         current turn's context activity.
      */
-    public CompletableFuture<RecognizerResult> recognize(
-        DialogContext dialogContext,
-        Activity activity,
-        LuisRecognizerOptions recognizerOptions,
-        Map<String, String> telemetryProperties,
-        Map<String, Double> telemetryMetrics
-    ) {
+    public CompletableFuture<RecognizerResult> recognize(DialogContext dialogContext, Activity activity,
+            LuisRecognizerOptions recognizerOptions, Map<String, String> telemetryProperties,
+            Map<String, Double> telemetryMetrics) {
         return recognizeInternal(dialogContext, activity, recognizerOptions, telemetryProperties, telemetryMetrics);
     }
 
     /**
      * Runs an utterance through a recognizer and returns a strongly-typed
      * recognizer result.
-     * 
+     *
      * @param turnContext         Context object containing information for a single
      *                            turn of conversation with a user.
      * @param recognizerOptions   A LuisRecognizerOptions instance to be used by the
@@ -440,21 +401,17 @@ public class LuisRecognizer extends TelemetryRecognizer {
      * @return The LUIS results of the analysis of the current message text in the
      *         current turn's context activity.
      */
-    public <T extends RecognizerConvert> CompletableFuture<T> recognize(
-        TurnContext turnContext,
-        LuisRecognizerOptions recognizerOptions,
-        Map<String, String> telemetryProperties,
-        Map<String, Double> telemetryMetrics,
-        Class<T> c
-    ) {
+    public <T extends RecognizerConvert> CompletableFuture<T> recognize(TurnContext turnContext,
+            LuisRecognizerOptions recognizerOptions, Map<String, String> telemetryProperties,
+            Map<String, Double> telemetryMetrics, Class<T> c) {
         return recognizeInternal(turnContext, recognizerOptions, telemetryProperties, telemetryMetrics)
-            .thenApply(recognizerResult -> convertRecognizerResult(recognizerResult, c));
+                .thenApply(recognizerResult -> convertRecognizerResult(recognizerResult, c));
     }
 
     /**
      * Runs an utterance through a recognizer and returns a strongly-typed
      * recognizer result.
-     * 
+     *
      * @param dialogContext       Context object containing information for a single
      *                            turn of conversation with a user.
      * @param activity            Activity to recognize.
@@ -471,21 +428,16 @@ public class LuisRecognizer extends TelemetryRecognizer {
      * @return The LUIS results of the analysis of the current message text in the
      *         current turn's context activity.
      */
-    public <T extends RecognizerConvert> CompletableFuture<T> recognize(
-        DialogContext dialogContext,
-        Activity activity,
-        LuisRecognizerOptions recognizerOptions,
-        Map<String, String> telemetryProperties,
-        Map<String, Double> telemetryMetrics,
-        Class<T> c
-    ) {
+    public <T extends RecognizerConvert> CompletableFuture<T> recognize(DialogContext dialogContext, Activity activity,
+            LuisRecognizerOptions recognizerOptions, Map<String, String> telemetryProperties,
+            Map<String, Double> telemetryMetrics, Class<T> c) {
         return recognizeInternal(dialogContext, activity, recognizerOptions, telemetryProperties, telemetryMetrics)
-            .thenApply(recognizerResult -> convertRecognizerResult(recognizerResult, c));
+                .thenApply(recognizerResult -> convertRecognizerResult(recognizerResult, c));
     }
 
     /**
      * Invoked prior to a LuisResult being logged.
-     * 
+     *
      * @param recognizerResult    The Luis Results for the call.
      * @param turnContext         Context object containing information for a single
      *                            turn of conversation with a user.
@@ -494,23 +446,25 @@ public class LuisRecognizer extends TelemetryRecognizer {
      * @param telemetryMetrics    Additional metrics to be logged to telemetry with
      *                            the LuisResult event.
      */
-    public void onRecognizerResult(
-        RecognizerResult recognizerResult,
-        TurnContext turnContext,
-        Map<String, String> telemetryProperties,
-        Map<String, Double> telemetryMetrics
-    ) {
-        Map<String, String> properties =
-            fillLuisEventPropertiesAsync(recognizerResult, turnContext, telemetryProperties);
+    public void onRecognizerResult(RecognizerResult recognizerResult, TurnContext turnContext,
+            Map<String, String> telemetryProperties, Map<String, Double> telemetryMetrics) {
+        Map<String, String> properties = fillLuisEventProperties(recognizerResult, turnContext,
+                telemetryProperties);
         // Track the event
         this.getTelemetryClient().trackEvent(LuisTelemetryConstants.LUIS_RESULT, properties, telemetryMetrics);
     }
 
-    private Map<String, String> fillLuisEventPropertiesAsync(
-        RecognizerResult recognizerResult,
-        TurnContext turnContext,
-        Map<String, String> telemetryProperties
-    ) {
+    /**
+     * Fills the event properties for LuisResult event for telemetry.
+     * These properties are logged when the recognizer is called.
+     *
+     * @param recognizerResult Last activity sent from user.
+     * @param turnContext Context object containing information for a single turn of conversation with a user.
+     * @param telemetryProperties Additional properties to be logged to telemetry with the LuisResult event.
+     * @return
+     */
+    private Map<String, String> fillLuisEventProperties(RecognizerResult recognizerResult, TurnContext turnContext,
+            Map<String, String> telemetryProperties) {
 
         Map<String, IntentScore> sortedIntents = sortIntents(recognizerResult);
         ArrayList<String> topTwoIntents = new ArrayList<>();
@@ -524,20 +478,16 @@ public class LuisRecognizer extends TelemetryRecognizer {
 
         // Add the intent score and conversation id properties
         Map<String, String> properties = new HashMap<>();
-        properties.put(
-            LuisTelemetryConstants.APPLICATION_ID_PROPERTY,
-            luisRecognizerOptions.getApplication().getApplicationId()
-        );
+        properties.put(LuisTelemetryConstants.APPLICATION_ID_PROPERTY,
+                luisRecognizerOptions.getApplication().getApplicationId());
         properties.put(LuisTelemetryConstants.INTENT_PROPERTY, topTwoIntents.size() > 0 ? topTwoIntents.get(0) : "");
-        properties.put(
-            LuisTelemetryConstants.INTENT_SCORE_PROPERTY,
-            topTwoIntents.size() > 0 ? "" + recognizerResult.getIntents().get(topTwoIntents.get(0)).getScore() : "0.00"
-        );
+        properties.put(LuisTelemetryConstants.INTENT_SCORE_PROPERTY,
+                topTwoIntents.size() > 0 ? "" + recognizerResult.getIntents().get(topTwoIntents.get(0)).getScore()
+                        : "0.00");
         properties.put(LuisTelemetryConstants.INTENT_2_PROPERTY, topTwoIntents.size() > 1 ? topTwoIntents.get(1) : "");
-        properties.put(
-            LuisTelemetryConstants.INTENT_SCORE_2_PROPERTY,
-            topTwoIntents.size() > 1 ? "" + recognizerResult.getIntents().get(topTwoIntents.get(1)).getScore() : "0.00"
-        );
+        properties.put(LuisTelemetryConstants.INTENT_SCORE_2_PROPERTY,
+                topTwoIntents.size() > 1 ? "" + recognizerResult.getIntents().get(topTwoIntents.get(1)).getScore()
+                        : "0.00");
         properties.put(LuisTelemetryConstants.FROM_ID_PROPERTY, turnContext.getActivity().getFrom().getId());
 
         if (recognizerResult.getProperties().containsKey("sentiment")) {
@@ -555,10 +505,7 @@ public class LuisRecognizer extends TelemetryRecognizer {
 
         // Use the LogPersonalInformation flag to toggle logging PII data, text is a
         // common example
-        if (
-            isLogPersonalInformation() && turnContext.getActivity().getText() != null
-                && !turnContext.getActivity().getText().equals("")
-        ) {
+        if (isLogPersonalInformation() && StringUtils.isNotBlank(turnContext.getActivity().getText())) {
             properties.put(LuisTelemetryConstants.QUESTION_PROPERTY, turnContext.getActivity().getText());
         }
 
@@ -579,12 +526,8 @@ public class LuisRecognizer extends TelemetryRecognizer {
             result.convert(recognizerResult);
         } catch (InstantiationException | IllegalAccessException e) {
             throw new RuntimeException(
-                String.format(
-                    "Exception thrown when converting " + "Recgonizer Result to strongly typed: %s : %s",
-                    clazz.getName(),
-                    e.getMessage()
-                )
-            );
+                    String.format("Exception thrown when converting " + "Recognizer Result to strongly typed: %s : %s",
+                            clazz.getName(), e.getMessage()));
         }
         return result;
     }
@@ -593,12 +536,9 @@ public class LuisRecognizer extends TelemetryRecognizer {
      * Returns a RecognizerResult object. This method will call the internal
      * recognize implementation of the Luis Recognizer Options.
      */
-    private CompletableFuture<RecognizerResult> recognizeInternal(
-        TurnContext turnContext,
-        LuisRecognizerOptions options,
-        Map<String, String> telemetryProperties,
-        Map<String, Double> telemetryMetrics
-    ) {
+    private CompletableFuture<RecognizerResult> recognizeInternal(TurnContext turnContext,
+            LuisRecognizerOptions options, Map<String, String> telemetryProperties,
+            Map<String, Double> telemetryMetrics) {
         LuisRecognizerOptions predictionOptionsToRun = options == null ? luisRecognizerOptions : options;
         return predictionOptionsToRun.recognizeInternal(turnContext).thenApply(recognizerResult -> {
             onRecognizerResult(recognizerResult, turnContext, telemetryProperties, telemetryMetrics);
@@ -610,13 +550,9 @@ public class LuisRecognizer extends TelemetryRecognizer {
      * Returns a RecognizerResult object. This method will call the internal
      * recognize implementation of the Luis Recognizer Options.
      */
-    private CompletableFuture<RecognizerResult> recognizeInternal(
-        DialogContext dialogContext,
-        Activity activity,
-        LuisRecognizerOptions options,
-        Map<String, String> telemetryProperties,
-        Map<String, Double> telemetryMetrics
-    ) {
+    private CompletableFuture<RecognizerResult> recognizeInternal(DialogContext dialogContext, Activity activity,
+            LuisRecognizerOptions options, Map<String, String> telemetryProperties,
+            Map<String, Double> telemetryMetrics) {
         LuisRecognizerOptions predictionOptionsToRun = options == null ? luisRecognizerOptions : options;
         return predictionOptionsToRun.recognizeInternal(dialogContext, activity).thenApply(recognizerResult -> {
             onRecognizerResult(recognizerResult, dialogContext.getContext(), telemetryProperties, telemetryMetrics);
@@ -626,11 +562,9 @@ public class LuisRecognizer extends TelemetryRecognizer {
 
     private Map<String, IntentScore> sortIntents(RecognizerResult recognizerResult) {
         Map<String, IntentScore> sortedIntents = new LinkedHashMap<>();
-        recognizerResult.getIntents()
-            .entrySet()
-            .stream()
-            .sorted(Map.Entry.comparingByValue(Comparator.comparingDouble(IntentScore::getScore).reversed()))
-            .forEachOrdered(x -> sortedIntents.put(x.getKey(), x.getValue()));
+        recognizerResult.getIntents().entrySet().stream()
+                .sorted(Map.Entry.comparingByValue(Comparator.comparingDouble(IntentScore::getScore).reversed()))
+                .forEachOrdered(x -> sortedIntents.put(x.getKey(), x.getValue()));
         return sortedIntents;
     }
 }

--- a/libraries/bot-ai-luis-v3/src/main/java/com/microsoft/bot/ai/luis/LuisRecognizerOptions.java
+++ b/libraries/bot-ai-luis-v3/src/main/java/com/microsoft/bot/ai/luis/LuisRecognizerOptions.java
@@ -20,7 +20,7 @@ public abstract class LuisRecognizerOptions {
 
     /**
      * Initializes an instance of the LuisRecognizerOptions implementation.
-     * 
+     *
      * @param application An instance of LuisApplication".
      */
     protected LuisRecognizerOptions(LuisApplication application) {
@@ -81,7 +81,7 @@ public abstract class LuisRecognizerOptions {
 
     /**
      * Indicates if personal information should be sent as telemetry.
-     * 
+     *
      * @return value boolean value to control personal information logging.
      */
     public boolean isLogPersonalInformation() {
@@ -90,7 +90,7 @@ public abstract class LuisRecognizerOptions {
 
     /**
      * Indicates if personal information should be sent as telemetry.
-     * 
+     *
      * @param logPersonalInformation to set personal information logging preference.
      */
     public void setLogPersonalInformation(boolean logPersonalInformation) {
@@ -100,7 +100,7 @@ public abstract class LuisRecognizerOptions {
     /**
      * Indicates if full results from the LUIS API should be returned with the
      * recognizer result.
-     * 
+     *
      * @return boolean value showing preference on LUIS API full response added to
      *         recognizer result.
      */
@@ -111,7 +111,7 @@ public abstract class LuisRecognizerOptions {
     /**
      * Indicates if full results from the LUIS API should be returned with the
      * recognizer result.
-     * 
+     *
      * @param includeAPIResults to set full Luis API response to be added to the
      *                          recognizer result.
      */
@@ -123,7 +123,7 @@ public abstract class LuisRecognizerOptions {
      * Implementation of the Luis API http call and result processing. This is
      * intended to follow a Strategy pattern and should only be consumed through the
      * LuisRecognizer class.
-     * 
+     *
      * @param turnContext used to extract the text utterance to be sent to Luis.
      * @return Recognizer Result populated by the Luis response.
      */
@@ -133,7 +133,7 @@ public abstract class LuisRecognizerOptions {
      * Implementation of the Luis API http call and result processing. This is
      * intended to follow a Strategy pattern and should only be consumed through the
      * LuisRecognizer class.
-     * 
+     *
      * @param context  Dialog Context to extract turn context.
      * @param activity to extract the text utterance to be sent to Luis.
      * @return Recognizer Result populated by the Luis response.

--- a/libraries/bot-ai-luis-v3/src/main/java/com/microsoft/bot/ai/luis/LuisRecognizerOptionsV3.java
+++ b/libraries/bot-ai-luis-v3/src/main/java/com/microsoft/bot/ai/luis/LuisRecognizerOptionsV3.java
@@ -458,7 +458,7 @@ public class LuisRecognizerOptionsV3 extends LuisRecognizerOptions {
         ObjectNode queryOptions = JsonNodeFactory.instance.objectNode().put("preferExternalEntities",
                 preferExternalEntities);
 
-        if (dateTimeReference != null && !dateTimeReference.isEmpty()) {
+        if (StringUtils.isNotBlank(dateTimeReference)) {
             queryOptions.put("datetimeReference", dateTimeReference);
         }
 

--- a/libraries/bot-ai-luis-v3/src/main/java/com/microsoft/bot/ai/luis/LuisRecognizerOptionsV3.java
+++ b/libraries/bot-ai-luis-v3/src/main/java/com/microsoft/bot/ai/luis/LuisRecognizerOptionsV3.java
@@ -16,6 +16,9 @@ import com.microsoft.bot.dialogs.DialogContext;
 import com.microsoft.bot.dialogs.Recognizer;
 import com.microsoft.bot.schema.Activity;
 import com.microsoft.bot.schema.ResourceResponse;
+
+import org.apache.commons.lang3.StringUtils;
+
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
@@ -40,11 +43,10 @@ import java.util.concurrent.CompletableFuture;
  */
 public class LuisRecognizerOptionsV3 extends LuisRecognizerOptions {
     private final HashSet<String> dateSubtypes = new HashSet<>(
-        Arrays.asList("date", "daterange", "datetime", "datetimerange", "duration", "set", "time", "timerange")
-    );
+            Arrays.asList("date", "daterange", "datetime", "datetimerange", "duration", "set", "time", "timerange"));
 
-    private final HashSet<String> geographySubtypes =
-        new HashSet<>(Arrays.asList("poi", "city", "countryRegion", "continent", "state"));
+    private final HashSet<String> geographySubtypes = new HashSet<>(
+            Arrays.asList("poi", "city", "countryRegion", "continent", "state"));
 
     private final String metadataKey = "$instance";
 
@@ -125,7 +127,7 @@ public class LuisRecognizerOptionsV3 extends LuisRecognizerOptions {
     /**
      * Gets External entity recognizer to recognize external entities to pass to
      * LUIS.
-     * 
+     *
      * @return externalEntityRecognizer
      */
     public Recognizer getExternalEntityRecognizer() {
@@ -135,7 +137,7 @@ public class LuisRecognizerOptionsV3 extends LuisRecognizerOptions {
     /**
      * Sets External entity recognizer to recognize external entities to pass to
      * LUIS.
-     * 
+     *
      * @param externalEntityRecognizer External Recognizer instance.
      */
     public void setExternalEntityRecognizer(Recognizer externalEntityRecognizer) {
@@ -145,7 +147,7 @@ public class LuisRecognizerOptionsV3 extends LuisRecognizerOptions {
     /**
      * Gets indicating whether all intents come back or only the top one. True for
      * returning all intents.
-     * 
+     *
      * @return True for returning all intents.
      */
     public boolean isIncludeAllIntents() {
@@ -154,7 +156,7 @@ public class LuisRecognizerOptionsV3 extends LuisRecognizerOptions {
 
     /**
      * Sets indicating whether all intents come back or only the top one.
-     * 
+     *
      * @param includeAllIntents True for returning all intents.
      */
     public void setIncludeAllIntents(boolean includeAllIntents) {
@@ -164,7 +166,7 @@ public class LuisRecognizerOptionsV3 extends LuisRecognizerOptions {
     /**
      * Gets value indicating whether or not instance data should be included in
      * response.
-     * 
+     *
      * @return True if instance data should be included in response.
      */
     public boolean isIncludeInstanceData() {
@@ -174,7 +176,7 @@ public class LuisRecognizerOptionsV3 extends LuisRecognizerOptions {
     /**
      * Sets value indicating whether or not instance data should be included in
      * response.
-     * 
+     *
      * @param includeInstanceData True if instance data should be included in
      *                            response.
      */
@@ -186,7 +188,7 @@ public class LuisRecognizerOptionsV3 extends LuisRecognizerOptions {
      * Value indicating whether queries should be logged in LUIS. If queries should
      * be logged in LUIS in order to help build better models through active
      * learning
-     * 
+     *
      * @return True if queries should be logged in LUIS.
      */
     public boolean isLog() {
@@ -197,7 +199,7 @@ public class LuisRecognizerOptionsV3 extends LuisRecognizerOptions {
      * Value indicating whether queries should be logged in LUIS. If queries should
      * be logged in LUIS in order to help build better models through active
      * learning.
-     * 
+     *
      * @param log True if queries should be logged in LUIS.
      */
     public void setLog(boolean log) {
@@ -206,7 +208,7 @@ public class LuisRecognizerOptionsV3 extends LuisRecognizerOptions {
 
     /**
      * Returns Dynamic lists used to recognize entities for a particular query.
-     * 
+     *
      * @return Dynamic lists used to recognize entities for a particular query
      */
     public List<DynamicList> getDynamicLists() {
@@ -215,7 +217,7 @@ public class LuisRecognizerOptionsV3 extends LuisRecognizerOptions {
 
     /**
      * Sets Dynamic lists used to recognize entities for a particular query.
-     * 
+     *
      * @param dynamicLists to recognize entities for a particular query.
      */
     public void setDynamicLists(List<DynamicList> dynamicLists) {
@@ -224,7 +226,7 @@ public class LuisRecognizerOptionsV3 extends LuisRecognizerOptions {
 
     /**
      * Gets External entities to be recognized in query.
-     * 
+     *
      * @return External entities to be recognized in query.
      */
     public List<ExternalEntity> getExternalEntities() {
@@ -233,7 +235,7 @@ public class LuisRecognizerOptionsV3 extends LuisRecognizerOptions {
 
     /**
      * Sets External entities to be recognized in query.
-     * 
+     *
      * @param externalEntities External entities to be recognized in query.
      */
     public void setExternalEntities(List<ExternalEntity> externalEntities) {
@@ -243,7 +245,7 @@ public class LuisRecognizerOptionsV3 extends LuisRecognizerOptions {
     /**
      * Gets value indicating whether external entities should override other means
      * of recognizing entities.
-     * 
+     *
      * @return True if external entities should be preferred to the results from
      *         LUIS models.
      */
@@ -254,7 +256,7 @@ public class LuisRecognizerOptionsV3 extends LuisRecognizerOptions {
     /**
      * Sets value indicating whether external entities should override other means
      * of recognizing entities.
-     * 
+     *
      * @param preferExternalEntities True if external entities should be preferred
      *                               to the results from LUIS models.
      */
@@ -264,7 +266,7 @@ public class LuisRecognizerOptionsV3 extends LuisRecognizerOptions {
 
     /**
      * Gets datetimeV2 offset. The format for the datetimeReference is ISO 8601.
-     * 
+     *
      * @return The format for the datetimeReference in ISO 8601.
      */
     public String getDateTimeReference() {
@@ -273,7 +275,7 @@ public class LuisRecognizerOptionsV3 extends LuisRecognizerOptions {
 
     /**
      * Sets datetimeV2 offset.
-     * 
+     *
      * @param dateTimeReference The format for the datetimeReference is ISO 8601.
      */
     public void setDateTimeReference(String dateTimeReference) {
@@ -285,7 +287,7 @@ public class LuisRecognizerOptionsV3 extends LuisRecognizerOptions {
      * production slot. You can find other standard slots in LuisSlot. If you
      * specify a Version, then a private version of the application is used instead
      * of a slot.
-     * 
+     *
      * @return LuisSlot constant.
      */
     public String getSlot() {
@@ -297,7 +299,7 @@ public class LuisRecognizerOptionsV3 extends LuisRecognizerOptions {
      * production slot. You can find other standard slots in LuisSlot. If you
      * specify a Version, then a private version of the application is used instead
      * of a slot.
-     * 
+     *
      * @param slot LuisSlot value to use.
      */
     public void setSlot(String slot) {
@@ -308,7 +310,7 @@ public class LuisRecognizerOptionsV3 extends LuisRecognizerOptions {
      * Gets the specific version of the application to access. LUIS supports
      * versions and this is the version to use instead of a slot. If this is
      * specified, then the Slot is ignored.
-     * 
+     *
      * @return Luis application version to Query.
      */
     public String getVersion() {
@@ -318,7 +320,7 @@ public class LuisRecognizerOptionsV3 extends LuisRecognizerOptions {
     /**
      * Sets the specific version of the application to access. LUIS supports
      * versions and this is the version to use instead of a slot.
-     * 
+     *
      * @param version Luis Application version. If this is specified, then the Slot
      *                is ignored.
      */
@@ -328,7 +330,7 @@ public class LuisRecognizerOptionsV3 extends LuisRecognizerOptions {
 
     /**
      * Gets whether the http client.
-     * 
+     *
      * @return OkHttpClient used to query the Luis Service.
      */
     public OkHttpClient getHttpClient() {
@@ -337,7 +339,7 @@ public class LuisRecognizerOptionsV3 extends LuisRecognizerOptions {
 
     /**
      * Sets the http client.
-     * 
+     *
      * @param httpClient to use for Luis Service http calls.
      */
     public void setHttpClient(OkHttpClient httpClient) {
@@ -346,7 +348,7 @@ public class LuisRecognizerOptionsV3 extends LuisRecognizerOptions {
 
     /**
      * Initializes a new instance of the LuisRecognizerOptionsV3.
-     * 
+     *
      * @param application Luis Application instance to query.
      */
     public LuisRecognizerOptionsV3(LuisApplication application) {
@@ -356,7 +358,7 @@ public class LuisRecognizerOptionsV3 extends LuisRecognizerOptions {
     /**
      * Internal implementation of the http request to the LUIS service and parsing
      * of the response to a Recognizer Result instance.
-     * 
+     *
      * @param dialogContext Context Object.
      * @param activity      Activity object to extract the utterance.
      */
@@ -402,11 +404,11 @@ public class LuisRecognizerOptionsV3 extends LuisRecognizerOptions {
                         int start = childInstance.get("startIndex").asInt();
                         int end = childInstance.get("endIndex").asInt();
                         recognizerExternalEntities
-                            .add(new ExternalEntity(property.getKey(), start, end - start, property.getValue()));
+                                .add(new ExternalEntity(property.getKey(), start, end - start, property.getValue()));
                     }
                 }
                 recognizerExternalEntities
-                    .addAll(originalExternalEntities == null ? new ArrayList<>() : originalExternalEntities);
+                        .addAll(originalExternalEntities == null ? new ArrayList<>() : originalExternalEntities);
                 externalEntities = recognizerExternalEntities;
             }
 
@@ -420,7 +422,7 @@ public class LuisRecognizerOptionsV3 extends LuisRecognizerOptions {
     /**
      * Internal implementation of the http request to the LUIS service and parsing
      * of the response to a Recognizer Result instance.
-     * 
+     *
      * @param turnContext Context Object.
      */
     @Override
@@ -445,8 +447,7 @@ public class LuisRecognizerOptionsV3 extends LuisRecognizerOptions {
         httpBuilder.addQueryParameter("show-all-intents", Boolean.toString(includeAllIntents));
 
         Request.Builder requestBuilder = new Request.Builder().url(httpBuilder.build())
-            .addHeader("Ocp-Apim-Subscription-Key", getApplication().getEndpointKey())
-            .post(body);
+                .addHeader("Ocp-Apim-Subscription-Key", getApplication().getEndpointKey()).post(body);
         return requestBuilder.build();
     }
 
@@ -454,8 +455,8 @@ public class LuisRecognizerOptionsV3 extends LuisRecognizerOptions {
 
         ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
         ObjectNode content = JsonNodeFactory.instance.objectNode().put("query", utterance);
-        ObjectNode queryOptions =
-            JsonNodeFactory.instance.objectNode().put("preferExternalEntities", preferExternalEntities);
+        ObjectNode queryOptions = JsonNodeFactory.instance.objectNode().put("preferExternalEntities",
+                preferExternalEntities);
 
         if (dateTimeReference != null && !dateTimeReference.isEmpty()) {
             queryOptions.put("datetimeReference", dateTimeReference);
@@ -611,7 +612,7 @@ public class LuisRecognizerOptionsV3 extends LuisRecognizerOptions {
                             }
                             nobj.put("endIndex", value);
                         } else if (!((isInt && name.equals("modelTypeId")) || // NOPMD
-                            (isString && name.equals("role"))) // NOPMD
+                                (isString && name.equals("role"))) // NOPMD
                         ) { // NOPMD
                             nobj.set(name, val);
                         }
@@ -681,21 +682,16 @@ public class LuisRecognizerOptionsV3 extends LuisRecognizerOptions {
         }
     }
 
-    private CompletableFuture<ResourceResponse> sendTraceActivity(
-        RecognizerResult recognizerResult,
-        JsonNode luisResponse,
-        TurnContext turnContext
-    ) {
+    private CompletableFuture<ResourceResponse> sendTraceActivity(RecognizerResult recognizerResult,
+            JsonNode luisResponse, TurnContext turnContext) {
         ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
         try {
             ObjectNode traceInfo = JsonNodeFactory.instance.objectNode();
-            traceInfo
-                .put("recognizerResult", mapper.writerWithDefaultPrettyPrinter().writeValueAsString(recognizerResult));
+            traceInfo.put("recognizerResult",
+                    mapper.writerWithDefaultPrettyPrinter().writeValueAsString(recognizerResult));
             traceInfo.set("luisResult", luisResponse);
-            traceInfo.set(
-                "luisModel",
-                JsonNodeFactory.instance.objectNode().put("ModelId", getApplication().getApplicationId())
-            );
+            traceInfo.set("luisModel",
+                    JsonNodeFactory.instance.objectNode().put("ModelId", getApplication().getApplicationId()));
 
             ObjectNode luisOptions = JsonNodeFactory.instance.objectNode();
             luisOptions.put("includeAllIntents", includeAllIntents);
@@ -725,8 +721,7 @@ public class LuisRecognizerOptionsV3 extends LuisRecognizerOptions {
             traceInfo.set("luisOptions", luisOptions);
 
             return turnContext.sendActivity(
-                Activity.createTraceActivity("LuisRecognizer", LUIS_TRACE_TYPE, traceInfo, LUIS_TRACE_LABEL)
-            );
+                    Activity.createTraceActivity("LuisRecognizer", LUIS_TRACE_TYPE, traceInfo, LUIS_TRACE_LABEL));
 
         } catch (IOException e) {
             CompletableFuture<ResourceResponse> exceptionResult = new CompletableFuture<>();

--- a/libraries/bot-ai-luis-v3/src/main/java/com/microsoft/bot/ai/luis/TelemetryRecognizer.java
+++ b/libraries/bot-ai-luis-v3/src/main/java/com/microsoft/bot/ai/luis/TelemetryRecognizer.java
@@ -14,6 +14,7 @@ import java.util.concurrent.CompletableFuture;
 
 /**
  * Telemetry Recognizer to enforce controls and properties on telemetry logged.
+ * Recognizer with Telemetry support.
  *
  */
 public abstract class TelemetryRecognizer implements Recognizer {
@@ -24,7 +25,7 @@ public abstract class TelemetryRecognizer implements Recognizer {
 
     /**
      * Indicates if personal information should be sent as telemetry.
-     * 
+     *
      * @return value boolean value to control personal information logging.
      */
     public boolean isLogPersonalInformation() {
@@ -33,7 +34,7 @@ public abstract class TelemetryRecognizer implements Recognizer {
 
     /**
      * Indicates if personal information should be sent as telemetry.
-     * 
+     *
      * @param logPersonalInformation to set personal information logging preference.
      */
     protected void setLogPersonalInformation(boolean logPersonalInformation) {
@@ -43,7 +44,7 @@ public abstract class TelemetryRecognizer implements Recognizer {
     /**
      * Gets the currently configured Bot Telemetry Client that logs the LuisResult
      * event.
-     * 
+     *
      * @return The Bot Telemetry Client.
      */
     protected BotTelemetryClient getTelemetryClient() {
@@ -53,7 +54,7 @@ public abstract class TelemetryRecognizer implements Recognizer {
     /**
      * Sets the currently configured Bot Telemetry Client that logs the LuisResult
      * event.
-     * 
+     *
      * @param telemetryClient Bot Telemetry Client.
      */
     public void setTelemetryClient(BotTelemetryClient telemetryClient) {
@@ -62,7 +63,7 @@ public abstract class TelemetryRecognizer implements Recognizer {
 
     /**
      * Return results of the analysis (Suggested actions and intents).
-     * 
+     *
      * @param turnContext         Context object containing information for a single
      *                            turn of conversation with a user.
      * @param telemetryProperties Additional properties to be logged to telemetry
@@ -72,15 +73,12 @@ public abstract class TelemetryRecognizer implements Recognizer {
      * @return The LUIS results of the analysis of the current message text in the
      *         current turn's context activity.
      */
-    abstract CompletableFuture<RecognizerResult> recognize(
-        TurnContext turnContext,
-        Map<String, String> telemetryProperties,
-        Map<String, Double> telemetryMetrics
-    );
+    abstract CompletableFuture<RecognizerResult> recognize(TurnContext turnContext,
+            Map<String, String> telemetryProperties, Map<String, Double> telemetryMetrics);
 
     /**
      * Return results of the analysis (Suggested actions and intents).
-     * 
+     *
      * @param turnContext         Context object containing information for a single
      *                            turn of conversation with a user.
      * @param telemetryProperties Additional properties to be logged to telemetry
@@ -92,11 +90,7 @@ public abstract class TelemetryRecognizer implements Recognizer {
      * @return The LUIS results of the analysis of the current message text in the
      *         current turn's context activity.
      */
-    abstract <T extends RecognizerConvert> CompletableFuture<T> recognize(
-        TurnContext turnContext,
-        Map<String, String> telemetryProperties,
-        Map<String, Double> telemetryMetrics,
-        Class<T> c
-    );
+    abstract <T extends RecognizerConvert> CompletableFuture<T> recognize(TurnContext turnContext,
+            Map<String, String> telemetryProperties, Map<String, Double> telemetryMetrics, Class<T> c);
 
 }

--- a/libraries/bot-ai-luis-v3/src/test/java/com/microsoft/bot/ai/luis/LuisApplicationTests.java
+++ b/libraries/bot-ai-luis-v3/src/test/java/com/microsoft/bot/ai/luis/LuisApplicationTests.java
@@ -61,7 +61,7 @@ public class LuisApplicationTests {
     }
 
     @Test
-    public void CreatesNewLuisApplication() {
+    public void createsNewLuisApplication() {
 
         LuisApplication lA = new LuisApplication(
             validUUID,
@@ -75,12 +75,25 @@ public class LuisApplicationTests {
     }
 
     @Test
-    public void CreatesNewLuisApplicationFromURL() {
+    public void createsNewLuisApplicationFromURL() {
         String url = "https://westus.api.cognitive.microsoft.com/luis/prediction/v3.0/apps/b31aeaf3-3511-495b-a07f-571fc873214b/slots/production/predict?verbose=true&timezoneOffset=-360&subscription-key=048ec46dc58e495482b0c447cfdbd291";
         LuisApplication lA = new LuisApplication(url);
 
         Assert.assertTrue(lA.getApplicationId().equals("b31aeaf3-3511-495b-a07f-571fc873214b"));
         Assert.assertTrue(lA.getEndpointKey().equals("048ec46dc58e495482b0c447cfdbd291"));
         Assert.assertTrue(lA.getEndpoint().equals("https://westus.api.cognitive.microsoft.com"));
+    }
+
+    @Test
+    public void listApplicationFromLuisEndpointBadArguments() {
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            LuisApplication lA = new LuisApplication("this.is.not.a.uri");
+        });
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            LuisApplication lA = new LuisApplication("https://westus.api.cognitive.microsoft.com/luis/v3.0/apps/b31aeaf3-3511-495b-a07f-571fc873214b?verbose=true&timezoneOffset=-360&q=");
+        });
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            LuisApplication lA = new LuisApplication("https://westus.api.cognitive.microsoft.com?verbose=true&timezoneOffset=-360&subscription-key=048ec46dc58e495482b0c447cfdbd291&q=");
+        });
     }
 }

--- a/libraries/bot-ai-luis-v3/src/test/java/com/microsoft/bot/ai/luis/LuisRecognizerOptionsV3Tests.java
+++ b/libraries/bot-ai-luis-v3/src/test/java/com/microsoft/bot/ai/luis/LuisRecognizerOptionsV3Tests.java
@@ -74,6 +74,7 @@ public class LuisRecognizerOptionsV3Tests {
             "ExternalEntitiesAndSimpleOverride.json",
             "GeoPeopleOrdinal.json",
             "Minimal.json",
+// TODO: This is disabled until the bug requiring instance data for geo is fixed.
 //        "MinimalWithGeo.json",
             "NoEntitiesInstanceTrue.json",
             "Patterns.json",

--- a/libraries/bot-ai-luis-v3/src/test/java/com/microsoft/bot/ai/luis/LuisRecognizerTests.java
+++ b/libraries/bot-ai-luis-v3/src/test/java/com/microsoft/bot/ai/luis/LuisRecognizerTests.java
@@ -68,9 +68,9 @@ public class LuisRecognizerTests {
 
     @Test
     public void topIntentReturnsTopIntent() {
-        String defaultIntent = LuisRecognizer
+        String greetingIntent = LuisRecognizer
             .topIntent(getMockedResult());
-        assertEquals(defaultIntent, "Greeting");
+        assertEquals(greetingIntent, "Greeting");
     }
 
     @Test


### PR DESCRIPTION
Related to 1166

## Description
We compared the structure/code migration/unit tests/documentation of the bot-ai-luis-v3 library between [Java](https://github.com/microsoft/botbuilder-java/tree/main/libraries/bot-ai-luis-v3) and [C#](https://github.com/microsoft/botbuilder-dotnet/tree/main/libraries/Microsoft.Bot.Builder.AI.LUIS) and we found disparities and fixes that this PR includes.

## Specific Changes
- Remove unused `application-insights` dependency from pom.xml
- Add missing unit test
- Remove set of length to -1 as empty length is 0
- Replace null/empty validation for isBlank/isNotBlank from StringUtils
- Apply naming convention for Java methods (lowerCamelCase)
- Fix javadocs and style

## Testing
_mvn clean install passing successfully_
![image](https://user-images.githubusercontent.com/11904023/119689155-feea5b00-be1e-11eb-92cf-69e886136397.png)