### PR TITLE
[Bot-ApplicationInsights] Fix disparities

### DIFF
--- a/libraries/bot-applicationinsights/pom.xml
+++ b/libraries/bot-applicationinsights/pom.xml
@@ -75,7 +75,6 @@
       <artifactId>bot-builder</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/libraries/bot-applicationinsights/src/main/java/com/microsoft/bot/applicationinsights/ApplicationInsightsBotTelemetryClient.java
+++ b/libraries/bot-applicationinsights/src/main/java/com/microsoft/bot/applicationinsights/ApplicationInsightsBotTelemetryClient.java
@@ -93,6 +93,7 @@ public class ApplicationInsightsBotTelemetryClient implements BotTelemetryClient
             concurrentMetrics,
             concurrentProperties
         );
+        telemetry.setTimestamp(new Date(timeStamp.toInstant().toEpochMilli()));
         if (properties != null) {
             for (Map.Entry<String, String> pair : properties.entrySet()) {
                 telemetry.getProperties().put(pair.getKey(), pair.getValue());

--- a/libraries/bot-applicationinsights/src/test/java/com/microsoft/bot/applicationinsights/BotTelemetryClientTests.java
+++ b/libraries/bot-applicationinsights/src/test/java/com/microsoft/bot/applicationinsights/BotTelemetryClientTests.java
@@ -100,7 +100,7 @@ public class BotTelemetryClientTests {
             Assert.assertEquals("test", eventTelemetry.getName());
             Assert.assertEquals("value", eventTelemetry.getProperties().get("hello"));
             Assert.assertEquals(0, Double.compare(0.6, eventTelemetry.getMetrics().get("metric")));
-        }).send(Mockito.any(AvailabilityTelemetry.class));
+        }).send(Mockito.any(EventTelemetry.class));
     }
 
     @Test
@@ -112,7 +112,8 @@ public class BotTelemetryClientTests {
             "data",
             OffsetDateTime.now(),
             Duration.ofNanos(1000),
-            "result", false);
+            "result",
+            false);
 
         Mockito.verify(mockTelemetryChannel, invocations -> {
             RemoteDependencyTelemetry remoteDependencyTelemetry = invocations.getAllInvocations().get(0).getArgument(0);
@@ -122,7 +123,7 @@ public class BotTelemetryClientTests {
             Assert.assertEquals("dependencyname", remoteDependencyTelemetry.getName());
             Assert.assertEquals("result", remoteDependencyTelemetry.getResultCode());
             Assert.assertFalse(remoteDependencyTelemetry.getSuccess());
-        }).send(Mockito.any(AvailabilityTelemetry.class));
+        }).send(Mockito.any(RemoteDependencyTelemetry.class));
     }
 
     @Test

--- a/libraries/bot-applicationinsights/src/test/java/com/microsoft/bot/applicationinsights/TelemetryInitializerTests.java
+++ b/libraries/bot-applicationinsights/src/test/java/com/microsoft/bot/applicationinsights/TelemetryInitializerTests.java
@@ -129,4 +129,13 @@ public class TelemetryInitializerTests {
         List<String> eventNames = eventNameCaptor.getAllValues();
         Assert.assertEquals(0, eventNames.size());
 	}
+
+	@Test
+    public void telemetryInitializerMiddlewareWithUndefinedContext() {
+        // Arrange
+	    BotTelemetryClient mockTelemetryClient = Mockito.mock(BotTelemetryClient.class);
+        TelemetryLoggerMiddleware telemetryLoggerMiddleware = new TelemetryLoggerMiddleware(mockTelemetryClient, false);
+        TelemetryInitializerMiddleware telemetryInitializerMiddleware = new TelemetryInitializerMiddleware(telemetryLoggerMiddleware, true);
+        Assert.assertThrows(IllegalArgumentException.class, () -> telemetryInitializerMiddleware.onTurn(null, () -> null));
+    }
 }

--- a/libraries/bot-applicationinsights/src/test/java/com/microsoft/bot/applicationinsights/TelemetryInitializerTests.java
+++ b/libraries/bot-applicationinsights/src/test/java/com/microsoft/bot/applicationinsights/TelemetryInitializerTests.java
@@ -133,9 +133,13 @@ public class TelemetryInitializerTests {
 	@Test
     public void telemetryInitializerMiddlewareWithUndefinedContext() {
         // Arrange
-	    BotTelemetryClient mockTelemetryClient = Mockito.mock(BotTelemetryClient.class);
+        BotTelemetryClient mockTelemetryClient = Mockito.mock(BotTelemetryClient.class);
         TelemetryLoggerMiddleware telemetryLoggerMiddleware = new TelemetryLoggerMiddleware(mockTelemetryClient, false);
         TelemetryInitializerMiddleware telemetryInitializerMiddleware = new TelemetryInitializerMiddleware(telemetryLoggerMiddleware, true);
-        Assert.assertThrows(IllegalArgumentException.class, () -> telemetryInitializerMiddleware.onTurn(null, () -> null));
+        // Assert
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            // Act
+            telemetryInitializerMiddleware.onTurn(null, () -> null);
+        });
     }
 }


### PR DESCRIPTION
Fix 1216
Related to 1166

## Description
We compared the structure/code migration/unit tests/documentation of the bot-applicationinsights library between [Java](https://github.com/microsoft/botbuilder-java/tree/main/libraries/bot-applicationinsights) and [C#](https://github.com/microsoft/botbuilder-dotnet/tree/main/libraries/Microsoft.Bot.Builder.ApplicationInsights) and we found disparities and fixes that this PR includes.

## Specific Changes
- Remove [test](https://github.com/microsoft/botbuilder-java/blob/main/libraries/bot-applicationinsights/pom.xml#L78) scope of botbuilder package in `pom.xml`
- Send correct type of telemetry depending on the unit test
- Add missing unit test to validate when the context is null in the [onTurn](https://github.com/microsoft/botbuilder-java/blob/main/libraries/bot-applicationinsights/src/main/java/com/microsoft/bot/applicationinsights/core/TelemetryInitializerMiddleware.java#L54) method
- Set timestamp to [AvailabilityTelemetry](https://github.com/microsoft/botbuilder-java/blob/main/libraries/bot-applicationinsights/src/main/java/com/microsoft/bot/applicationinsights/ApplicationInsightsBotTelemetryClient.java#L87-L95) in _trackAvailability_ method

## Testing
_mvn clean install passing successfully_
![image](https://user-images.githubusercontent.com/11904023/120213115-35521c80-c209-11eb-9f3b-7b14e9e6cd2e.png)
