### PR TITLE
[Linter] Upgrade Checkstyle plugin to 3.1.2 supporting Checkstyle version up to 8.41

### DIFF
--- a/etc/bot-checkstyle.xml
+++ b/etc/bot-checkstyle.xml
@@ -85,6 +85,10 @@
 
     <module name="SuppressWarningsFilter" />
 
+    <module name="LineLength">
+      <property name="max" value="120"/>
+    </module>
+
     <module name="TreeWalker">
         <!-- check for usage of literal equality "==" between string -->
         <module name="StringLiteralEquality"/>
@@ -125,10 +129,7 @@
         </module>
 
         <!-- Checks for Size Violations.                    -->
-        <!-- See http://checkstyle.sourceforge.net/config_sizes.html -->
-        <module name="LineLength">
-          <property name="max" value="120"/>
-        </module>
+        <!-- See http://checkstyle.sourceforge.net/config_sizes.html -->        
         <module name="MethodLength"/>
         <module name="ParameterNumber"/>
 

--- a/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/RegisterClassMiddleware.java
+++ b/libraries/bot-builder/src/main/java/com/microsoft/bot/builder/RegisterClassMiddleware.java
@@ -57,12 +57,12 @@ public class RegisterClassMiddleware<T> implements Middleware {
         this.service = withService;
     }
 
-    @Override
     /**
      * Adds the associated object or service to the current turn context.
      * @param turnContext The context object for this turn.
      * @param next The delegate to call to continue the bot middleware pipeline.
      */
+    @Override
     public CompletableFuture<Void> onTurn(TurnContext turnContext, NextDelegate next) {
         if (!StringUtils.isBlank(key)) {
             turnContext.getTurnState().add(key, service);

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <jdk.version>1.8</jdk.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <checkstyle.version>3.1.0</checkstyle.version>
+    <checkstyle.version>3.1.2</checkstyle.version>
     <pmd.version>3.14.0</pmd.version>
     <exclude.tests>%regex[.*recognizers.*]</exclude.tests>
     <!-- <repo.id>MyGet</repo.id> -->


### PR DESCRIPTION
Fixes 1215

## Description
The current Checkstyle rules cannot be consumed by the Checkstyle plugin greater or equal than 8.24. For this, we updated the checkstyle plugin integrated in the [pom.xml](https://github.com/microsoft/botbuilder-java/blob/main/pom.xml#L21) from 3.1.0 to 3.1.2 (latest) which defaults to checkstyle 8.29.

With the update of the rules, we support up to the checkstyle version 8.41 inclusive, solving the breaking change mentioned in the checkstyle release [8.24](https://checkstyle.org/releasenotes.html#Release_8.24).

Last but not least, the checkstyle version [8.42](https://checkstyle.org/releasenotes.html#Release_8.42) has another breaking change which is not supported with this PR.

![image](https://user-images.githubusercontent.com/11904023/121373194-412e9480-c915-11eb-82d3-2275f1f908ca.png)

## Specific Changes
 - Upgrade checkstyle plugin to latest [3.1.2](https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-checkstyle-plugin/3.1.2) which defaults to checkstyle [8.29](https://checkstyle.org/releasenotes.html#Release_8.29)
 - Update rules to support Checkstyle version up to [8.41](https://checkstyle.org/releasenotes.html#Release_8.41.1)
 - Fix linter issues

## Testing
_mvn clean install passing correctly_
![image](https://user-images.githubusercontent.com/11904023/121372412-a8981480-c914-11eb-901a-9644a078a131.png)